### PR TITLE
Add console-header to chart

### DIFF
--- a/stable/console-chart/templates/console-header-configmap.yaml
+++ b/stable/console-chart/templates/console-header-configmap.yaml
@@ -1,6 +1,4 @@
-# Licensed Materials - Property of IBM
-# (C) Copyright IBM Corporation 2020 All Rights Reserved
-# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# Copyright (c) 2020 Red Hat, Inc.
 
 apiVersion: v1
 kind: ConfigMap

--- a/stable/console-chart/templates/console-header-daemonset.yaml
+++ b/stable/console-chart/templates/console-header-daemonset.yaml
@@ -1,6 +1,4 @@
-# Licensed Materials - Property of IBM
-# (C) Copyright IBM Corporation 2020 All Rights Reserved
-# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# Copyright (c) 2020 Red Hat, Inc.
 
 apiVersion: apps/v1
 kind: DaemonSet
@@ -82,7 +80,7 @@ spec:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
 {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
-            runAsUser: 1000
+            runAsUser: 10010100001
 {{- end }}
             capabilities:
               add:

--- a/stable/console-chart/templates/console-header-default-nav-cr.yaml
+++ b/stable/console-chart/templates/console-header-default-nav-cr.yaml
@@ -1,6 +1,4 @@
-# Licensed Materials - Property of IBM
-# (C) Copyright IBM Corporation 2020 All Rights Reserved
-# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# Copyright (c) 2020 Red Hat, Inc.
 
 apiVersion: console.acm.com/v1
 kind: NavConfiguration
@@ -95,7 +93,7 @@ spec:
     - "chisels, version 9722dbc, GPL"
     - "MongoDB, version 4.0.12, SSPL"
     - "ffi (Ruby Gem), 1.11.1, GPL"
-    copyright: "© 2018, 2019 IBM. All rights reserved."
+    copyright: "© 2019 IBM. All rights reserved. Copyright (c) 2020 Red Hat, Inc."
     version: "1.0.0"
   logoutRedirects:
     - /cemui/logout

--- a/stable/console-chart/templates/console-header-ingress.yaml
+++ b/stable/console-chart/templates/console-header-ingress.yaml
@@ -1,6 +1,4 @@
-# Licensed Materials - Property of IBM
-# (C) Copyright IBM Corporation 2020 All Rights Reserved
-# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# Copyright (c) 2020 Red Hat, Inc.
 
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/stable/console-chart/templates/console-header-log-config.yaml
+++ b/stable/console-chart/templates/console-header-log-config.yaml
@@ -1,6 +1,4 @@
-# Licensed Materials - Property of IBM
-# (C) Copyright IBM Corporation 2020 All Rights Reserved
-# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# Copyright (c) 2020 Red Hat, Inc.
 
 apiVersion: v1
 kind: ConfigMap

--- a/stable/console-chart/templates/console-header-service.yaml
+++ b/stable/console-chart/templates/console-header-service.yaml
@@ -1,6 +1,4 @@
-# Licensed Materials - Property of IBM
-# (C) Copyright IBM Corporation 2020 All Rights Reserved
-# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# Copyright (c) 2020 Red Hat, Inc.
 
 apiVersion: v1
 kind: Service

--- a/stable/console-chart/templates/nav-api-ingress.yaml
+++ b/stable/console-chart/templates/nav-api-ingress.yaml
@@ -1,6 +1,4 @@
-# Licensed Materials - Property of IBM
-# (C) Copyright IBM Corporation 2020 All Rights Reserved
-# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# Copyright (c) 2020 Red Hat, Inc.
 
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/stable/console-chart/templates/nav-callback-ingress.yaml
+++ b/stable/console-chart/templates/nav-callback-ingress.yaml
@@ -1,6 +1,4 @@
-# Licensed Materials - Property of IBM
-# (C) Copyright IBM Corporation 2020 All Rights Reserved
-# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# Copyright (c) 2020 Red Hat, Inc.
 
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/stable/console-chart/templates/nav-crd.yaml
+++ b/stable/console-chart/templates/nav-crd.yaml
@@ -1,7 +1,5 @@
 ---
-# Licensed Materials - Property of IBM
-# (C) Copyright IBM Corporation 2020 All Rights Reserved
-# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# Copyright (c) 2020 Red Hat, Inc.
 
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/stable/console-chart/templates/user-preference-crd.yaml
+++ b/stable/console-chart/templates/user-preference-crd.yaml
@@ -1,6 +1,4 @@
-# Licensed Materials - Property of IBM
-# (C) Copyright IBM Corporation 2020 All Rights Reserved
-# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# Copyright (c) 2020 Red Hat, Inc.
 
 # Dynamic user preference data
 # The CR will be created with the name of the user who will access the information

--- a/stable/console-chart/values.yaml
+++ b/stable/console-chart/values.yaml
@@ -75,10 +75,10 @@ consoleapi:
         memory: "512Mi"
         cpu: "300m"
     uiconfig:
-      icpText: "Red Hat Advanced Cluster Management for Kubernetes for Kubernetes"
+      icpText: "Red Hat Advanced Cluster Management for Kubernetes"
       about:
-        text: "Red Hat Advanced Cluster Management for Kubernetes for Kubernetes"
-        logoAltText: "Red Hat Advanced Cluster Management for Kubernetes for Kubernetes"
+        text: "Red Hat Advanced Cluster Management for Kubernetes"
+        logoAltText: "Red Hat Advanced Cluster Management for Kubernetes"
         edition: "Enterprise"
       header:
         path: "/multicloud/header/graphics/RHACM-logo.svg"
@@ -86,4 +86,4 @@ consoleapi:
         height: "18px"
         supportUrl: "https://ibm.biz/icpsupport"
         docUrlMapping: "/examples/header/custom"
-        logoAltText: "Red Hat Advanced Cluster Management for Kubernetes for Kubernetes"
+        logoAltText: "Red Hat Advanced Cluster Management for Kubernetes"


### PR DESCRIPTION
Adding console-header to chart
includes:
 - header daemonset, service & ingress
 - Left nav CRD and the default nav CR
 - User preference CRD (this is still a bit of a WIP)