### PR TITLE
Correct product name and update apigroup to open-cluster-management.io

### DIFF
--- a/stable/console-chart/charts/console-crd/templates/user-preference-crd-deprecated.yaml
+++ b/stable/console-chart/charts/console-crd/templates/user-preference-crd-deprecated.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2020 Red Hat, Inc.
+
+# !!!!!!!!!!!!!!!!!!!!!!!!
+# This CRD is deprecated.
+# Keeping it here until dependencies are migrated to the new api group (console.open-cluster-management.io)
+# !!!!!!!!!!!!!!!!!!!!!!!!
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: userpreferences.console.acm.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: console.acm.io
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: userpreferences
+    # singular name to be used as an alias on the CLI and for display
+    singular: userpreference
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: UserPreference

--- a/stable/console-chart/charts/console-crd/templates/user-preference-crd.yaml
+++ b/stable/console-chart/charts/console-crd/templates/user-preference-crd.yaml
@@ -9,10 +9,10 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: userpreferences.console.acm.io
+  name: userpreferences.console.open-cluster-management.io
 spec:
   # group name to use for REST API: /apis/<group>/<version>
-  group: console.acm.io
+  group: console.open-cluster-management.io
   # list of versions supported by this CustomResourceDefinition
   versions:
     - name: v1

--- a/stable/console-chart/templates/console-link.yaml
+++ b/stable/console-chart/templates/console-link.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   href: https://multicloud-console.{{ .Values.ocpingress }}
   location: ApplicationMenu
-  text: Red Hat Advanced Cluster Management
+  text: Red Hat Advanced Cluster Management for Kubernetes
   applicationMenu:
     section: Red Hat Applications
     imageURL: https://multicloud-console.{{ .Values.ocpingress }}/multicloud/header/graphics/RHACM-logo_24x24.svg


### PR DESCRIPTION
- Product name updated to "Advanced Cluster Management **for Kubernetes**"
- Update apigroup in userpreferences CRD.