### PR TITLE
[RFA] Add ClusterImageSets to the chart via customerResources instead of coded in console-ui

### DIFF
--- a/stable/console-chart/templates/clusterimageset-clusterrole.yaml
+++ b/stable/console-chart/templates/clusterimageset-clusterrole.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 Red Hat, Inc.
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-clusterimagesets-readonly
+  labels:
+    # Add these permissions to the "view" default role.
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["hive.openshift.io"]
+  resources: ["clusterimagesets"]
+  verbs: ["get", "list", "watch"]

--- a/stable/console-chart/templates/clusterimageset-clusterrolebinding.yaml
+++ b/stable/console-chart/templates/clusterimageset-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 Red Hat, Inc.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: readonly-clusterimagesets
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: aggregate-clusterimagesets-readonly
+  apiGroup: rbac.authorization.k8s.io

--- a/stable/console-chart/templates/img4.3.12-x86_64.yaml
+++ b/stable/console-chart/templates/img4.3.12-x86_64.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+    name: img4.3.12-x86-64
+    labels:
+      channel: stable
+spec:
+    releaseImage: quay.io/openshift-release-dev/ocp-release:4.3.12-x86_64

--- a/stable/console-chart/templates/img4.3.13-x86_64.yaml
+++ b/stable/console-chart/templates/img4.3.13-x86_64.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+    name: img4.3.13-x86-64
+    labels:
+      channel: stable
+spec:
+    releaseImage: quay.io/openshift-release-dev/ocp-release:4.3.13-x86_64

--- a/stable/console-chart/templates/img4.4.0-rc.13-x86_64.yaml
+++ b/stable/console-chart/templates/img4.4.0-rc.13-x86_64.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+    name: img4.4.0-rc.13-fast
+    labels:
+      channel: fast
+spec:
+    releaseImage: quay.io/openshift-release-dev/ocp-release:4.4.0-rc.13-x86_64


### PR DESCRIPTION
Add ClusterImageSets resources:
- img4.3.12
- img4.3.13
- img4.4.0-rc.13

ClusterRole for clusterImageSets
ClusterRoleBinding to the system:authenticated group