### PR TITLE
Update clusterrole to add ManagedClusterView and ManagedClusterAction

### DIFF
--- a/stable/console-chart/templates/console-clusterrole.yaml
+++ b/stable/console-chart/templates/console-clusterrole.yaml
@@ -54,3 +54,10 @@ rules:
   - create
   - get
   - delete
+- apiGroups:
+  - proxy.open-cluster-management.io
+  resources:
+  - clusterstatuses
+  verbs:
+  - get
+  - post


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/2243

Update the console-clusterrole to add access to create/get/delete the resources ManagedClusterView and ManagedClusterAction, which are part of the 2.0 API migration.