### PR TITLE
Add sessionAffinity to cluster-api

### DIFF
--- a/stable/console-chart/templates/hcmuiapi-service.yaml
+++ b/stable/console-chart/templates/hcmuiapi-service.yaml
@@ -1,6 +1,7 @@
 # Licensed Materials - Property of IBM
 # (C) Copyright IBM Corporation 2016, 2019 All Rights Reserved
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# Copyright (c) 2020 Red Hat, Inc.
 
 apiVersion: v1
 kind: Service
@@ -26,3 +27,4 @@ spec:
     app: {{ template "console.name" . }}
     component: "consoleapi"
     release: {{ .Release.Name }}
+  sessionAffinity: ClientIP


### PR DESCRIPTION
Now that we have enabled HA, the cache on console-api isn't as effective. By enabling sessionAffinity, client requests will continue to get routed to the same pod, so we can reuse the cached settings.

I've tested this on the search-api.  https://github.com/open-cluster-management/search-chart/pull/34