### PR TITLE
Update ClusterImageSets

### DIFF
--- a/stable/console-chart/templates/img4.3.21-x86_64.yaml
+++ b/stable/console-chart/templates/img4.3.21-x86_64.yaml
@@ -1,8 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  labels:
-    channel: fast
-  name: img4.3.21-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.3.21-x86_64

--- a/stable/console-chart/templates/img4.3.25-x86_64.yaml
+++ b/stable/console-chart/templates/img4.3.25-x86_64.yaml
@@ -1,8 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  labels:
-    channel: fast
-  name: img4.3.25-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.3.25-x86_64

--- a/stable/console-chart/templates/img4.3.27-x86_64.yaml
+++ b/stable/console-chart/templates/img4.3.27-x86_64.yaml
@@ -1,0 +1,12 @@
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+  labels:
+    channel: stable
+    platform.aws: 'true'
+    platform.azure: 'true'
+    platform.gcp: 'true'
+    visible: 'true'
+  name: img4.3.27-x86-64
+spec:
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.3.27-x86_64

--- a/stable/console-chart/templates/img4.4.10-x86_64.yaml
+++ b/stable/console-chart/templates/img4.4.10-x86_64.yaml
@@ -1,0 +1,12 @@
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+  labels:
+    channel: stable
+    platform.aws: 'true'
+    platform.azure: 'true'
+    platform.gcp: 'true'
+    visible: 'true'
+  name: img4.4.10-x86-64
+spec:
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.4.10-x86_64

--- a/stable/console-chart/templates/img4.4.6-x86_64.yaml
+++ b/stable/console-chart/templates/img4.4.6-x86_64.yaml
@@ -1,8 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  labels:
-    channel: fast
-  name: img4.4.6-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.4.6-x86_64

--- a/stable/console-chart/templates/img4.4.8-x86_64.yaml
+++ b/stable/console-chart/templates/img4.4.8-x86_64.yaml
@@ -1,8 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  labels:
-    channel: fast
-  name: img4.4.8-x86-64
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.4.8-x86_64

--- a/stable/console-chart/templates/img4.5.0-rc.1-x86_64.yaml
+++ b/stable/console-chart/templates/img4.5.0-rc.1-x86_64.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-    name: img4.5.0-rc.1-x86-64
-    labels:
-      channel: candidate
-spec:
-    releaseImage: quay.io/openshift-release-dev/ocp-release:4.5.0-rc.1-x86_64

--- a/stable/console-chart/templates/img4.5.0-rc.6-x86_64.yaml
+++ b/stable/console-chart/templates/img4.5.0-rc.6-x86_64.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+  name: img4.5.0-rc.6-x86-64
+  labels:
+    channel: candidate
+    platform.aws: "true"
+    platform.gcp: "true"
+    platform.azure: "true"
+    visible: "true"
+spec:
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.5.0-rc.6-x86_64


### PR DESCRIPTION
As per discussion with @berenss I only supply the latest tested versions for 4.3, 4.4 and 4.5

We need to find out if we will get 4.5.0 before we GA.