### PR TITLE
Stage the 4.5.0 ClusterImageSet

### DIFF
--- a/stable/console-chart/templates/img4.5.0-x86_64.yaml
+++ b/stable/console-chart/templates/img4.5.0-x86_64.yaml
@@ -2,12 +2,12 @@
 apiVersion: hive.openshift.io/v1
 kind: ClusterImageSet
 metadata:
-  name: img4.5.0-rc.6-x86-64
+  name: img4.5.0-x86-64
   labels:
-    channel: candidate
+    channel: fast
     platform.aws: "true"
     platform.gcp: "true"
     platform.azure: "true"
     visible: "true"
 spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.5.0-rc.6-x86_64
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.5.0-x86_64


### PR DESCRIPTION
This is a fake clusterImageSet for the 4.5 OCP release.

It was discussed that we would create this even though it does not exist, as we don't want to have to do a build on July 13 if we can avoid it. This will hopefully avoid a rebuild on OCP 4.5 GA