### PR TITLE
Add 4.5.2 as the default 4.5 release

### DIFF
--- a/stable/console-chart/templates/img4.5.2-x86_64.yaml
+++ b/stable/console-chart/templates/img4.5.2-x86_64.yaml
@@ -2,7 +2,7 @@
 apiVersion: hive.openshift.io/v1
 kind: ClusterImageSet
 metadata:
-  name: img4.5.1-x86-64
+  name: img4.5.2-x86-64
   labels:
     channel: fast
     platform.aws: "true"
@@ -10,4 +10,4 @@ metadata:
     platform.azure: "true"
     visible: "true"
 spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.5.1-x86_64
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.5.2-x86_64


### PR DESCRIPTION
This is a result of yesterdays announcement for 4.5 GA.
Issue: https://github.com/open-cluster-management/backlog/issues/3556