### PR TITLE
Change conditional logic for installing console deployment

### DIFF
--- a/stable/console-chart/templates/console-deployment.yaml
+++ b/stable/console-chart/templates/console-deployment.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) 2020 Red Hat, Inc.
 
-{{- if .Values.global.imageOverrides.console }}
+{{- if .Values.console.install }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/stable/console-chart/values.yaml
+++ b/stable/console-chart/values.yaml
@@ -37,6 +37,7 @@ hubconfig:
   replicaCount: 1
 
 console:
+  install: false
   resources:
     requests:
       memory: "256Mi"


### PR DESCRIPTION
`global.imageOverrides` will always be set by installer; so the deployment will always get installed.  Need to set differently; until we have console images getting pushed to quay

Issue:  https://github.com/open-cluster-management/backlog/issues/6957
Issue:  https://github.com/open-cluster-management/backlog/issues/6949