### PR TITLE
Remove the app resource for the ClusterImageSets subscriptions.

### DIFF
--- a/stable/console-chart/templates/application.yaml
+++ b/stable/console-chart/templates/application.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: app.k8s.io/v1beta1
-kind: Application
-metadata:
-  name: hive-clusterimagesets
-spec:
-  selector:
-    matchLabels:
-      app: hive-clusterimagesets


### PR DESCRIPTION
This is the related issue: https://github.com/open-cluster-management/backlog/issues/6970