### PR TITLE
[2.5] Allow list & watch for CRDs

### DIFF
--- a/stable/console-chart/templates/console-clusterrole.yaml
+++ b/stable/console-chart/templates/console-clusterrole.yaml
@@ -199,3 +199,11 @@ rules:
   verbs:
   - list
   - watch
+
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

Related issue: https://github.com/stolostron/backlog/issues/26143

Allow console to watch for CRDs - this fix is required for the resource plural issue.