### PR TITLE
ACM-3043 ingress class annotation deprecated

### DIFF
--- a/stable/console-chart/templates/console-ingress.yaml
+++ b/stable/console-chart/templates/console-ingress.yaml
@@ -19,6 +19,7 @@ metadata:
     app.kubernetes.io/name: {{ template "console.name" . }}
     helm.sh/chart: {{ template "console.chart" . }}
 spec:
+  ingressClassName: ingress-open-cluster-management
   rules:
   - http:
       paths:


### PR DESCRIPTION
use spec.ingressClassName

Signed-off-by: Kevin Cormier <kcormier@redhat.com>